### PR TITLE
Add first gittuf TSC

### DIFF
--- a/TECHNICAL-STEERING-COMMITTEE.md
+++ b/TECHNICAL-STEERING-COMMITTEE.md
@@ -1,0 +1,33 @@
+# Technical Steering Committee (TSC)
+
+The current gittuf is composed of the following individuals.
+
+## Justin Cappos
+
+Affiliation: New York University (academia)
+
+GitHub: @JustinCappos
+
+## Aditya Sirish A Yelgundhalli
+
+Affiliation: New York University (academia)
+
+GitHub: @adityasaky
+
+## Billy Lynch
+
+Affiliation: Chainguard (industry)
+
+GitHub: @wlynch
+
+## Reza Curtmola
+
+Affiliation: New Jersey Institute of Technology (academia)
+
+GitHub: @reza-curtmola
+
+## Michael Lieberman
+
+Affiliation: Kusari (industry)
+
+GitHub: @mlieberman85


### PR DESCRIPTION
This PR adds an initial technical steering committee for gittuf in anticipation of the charter we aim to adopt (see: #1 and https://github.com/gittuf/gittuf/issues/128). Please approve the PR to confirm your intent to join the TSC!

@JustinCappos @wlynch @reza-curtmola @mlieberman85