### PR TITLE
Fix typo in TSC doc

### DIFF
--- a/TECHNICAL-STEERING-COMMITTEE.md
+++ b/TECHNICAL-STEERING-COMMITTEE.md
@@ -1,6 +1,6 @@
 # Technical Steering Committee (TSC)
 
-The current gittuf is composed of the following individuals.
+The current gittuf TSC is composed of the following individuals.
 
 ## Justin Cappos
 


### PR DESCRIPTION
Noticed this when adding the mentorship docs before.