### PR TITLE
Update community meeting note links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ community aspects of gittuf.
 Come say hello! We're on the OpenSSF Slack workspace and we hold a community
 meeting on the first Friday of every month at 12 PM eastern time.
 
-| Reference | Link |
-|-----------|------|
-| Repository | https://github.com/gittuf/gittuf |
-| Website | https://gittuf.dev |
-| Slack | https://openssf.slack.com/archives/C05QVUN4WUW |
-| Mailing List | gittuf-community@lists.openssf.org ([archive](https://lists.openssf.org/g/gittuf-community/topics)) |
-| Community Meeting Notes | https://docs.google.com/document/d/1tXFCVUHsICLpLKxcGvhzBDUWmpsY1LQvysFaX6AJRkk/edit?usp=sharing |
+| Reference               | Link                                                                                                                                                                                       |
+|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Repository              | https://github.com/gittuf/gittuf                                                                                                                                                           |
+| Website                 | https://gittuf.dev                                                                                                                                                                         |
+| Slack                   | https://openssf.slack.com/archives/C05QVUN4WUW                                                                                                                                             |
+| Mailing List            | gittuf-community@lists.openssf.org ([archive](https://lists.openssf.org/g/gittuf-community/topics))                                                                                        |
+| Community Meeting Notes | [2025](https://docs.google.com/document/d/1EbFAZu_pxayLwr4QWxhKCSZYhyJAcya7K-b_kuXlmpU/edit), [2024](https://docs.google.com/document/d/1tXFCVUHsICLpLKxcGvhzBDUWmpsY1LQvysFaX6AJRkk/edit) |


### PR DESCRIPTION
This PR updates the community meeting note docs, flagged in the TI Audit review at the most recent WG meeting (see https://docs.google.com/document/d/1moVFPn5pLi-uGs840_YBCrwdpHajU0ptFmlL4F9GryQ/edit).